### PR TITLE
Limit Fetching & Removing Parameters to Groups of 10

### DIFF
--- a/src/CredentialClient.php
+++ b/src/CredentialClient.php
@@ -26,7 +26,7 @@ use PMG\CredCommands\Formatter\NullFormatter;
  */
 class CredentialClient
 {
-    const MAX_SIZE = 10;
+    const MAX_NAMES = 10;
 
     /**
      * @var SsmClient
@@ -91,7 +91,7 @@ class CredentialClient
         }
 
         $params = [];
-        foreach (array_chunk(array_keys($keys), self::MAX_SIZE) as $names) {
+        foreach (array_chunk(array_keys($keys), self::MAX_NAMES) as $names) {
             $result = $this->ssm->getParameters([
                 'Names' => $names,
                 'WithDecryption' => true,
@@ -149,7 +149,7 @@ class CredentialClient
     public function remove(string $credential, string ...$credentials) : void
     {
         array_unshift($credentials, $credential);
-        foreach (array_chunk(array_map([$this, 'format'], $credentials), self::MAX_SIZE) as $names) {
+        foreach (array_chunk(array_map([$this, 'format'], $credentials), self::MAX_NAMES) as $names) {
             $this->ssm->deleteParameters([
                 'Names' => $names,
             ]);

--- a/src/CredentialClient.php
+++ b/src/CredentialClient.php
@@ -26,6 +26,8 @@ use PMG\CredCommands\Formatter\NullFormatter;
  */
 class CredentialClient
 {
+    const MAX_SIZE = 10;
+
     /**
      * @var SsmClient
      */
@@ -88,20 +90,25 @@ class CredentialClient
             $keys[$this->format($c)] = $c;
         }
 
-        $result = $this->ssm->getParameters([
-            'Names' => array_keys($keys),
-            'WithDecryption' => true,
-        ]);
+        $params = [];
+        foreach (array_chunk(array_keys($keys), self::MAX_SIZE) as $names) {
+            $result = $this->ssm->getParameters([
+                'Names' => $names,
+                'WithDecryption' => true,
+            ]);
 
-        if (!empty($result['InvalidParameters'])) {
-            throw new InvalidParameters(sprintf(
-                'Invalid Parameters: %s',
-                implode(', ', $result['InvalidParameters'])
-            ));
+            if (!empty($result['InvalidParameters'])) {
+                throw new InvalidParameters(sprintf(
+                    'Invalid Parameters: %s',
+                    implode(', ', $result['InvalidParameters'])
+                ));
+            }
+
+            $params[] = $result['Parameters'] ?: [];
         }
 
         $out = [];
-        foreach ($result['Parameters'] as $param) {
+        foreach (array_merge(...$params) as $param) {
             $origName = $keys[$param['Name']];
             $out[$origName] = $param['Value'];
         }
@@ -142,9 +149,11 @@ class CredentialClient
     public function remove(string $credential, string ...$credentials) : void
     {
         array_unshift($credentials, $credential);
-        $this->ssm->deleteParameters([
-            'Names' => array_map([$this, 'format'], $credentials),
-        ]);
+        foreach (array_chunk(array_map([$this, 'format'], $credentials), self::MAX_SIZE) as $names) {
+            $this->ssm->deleteParameters([
+                'Names' => $names,
+            ]);
+        }
     }
 
     private function format(string $credential) : string

--- a/test/CredentialClientTest.php
+++ b/test/CredentialClientTest.php
@@ -63,6 +63,26 @@ class CredentialClientTest extends TestCase
         $this->client->remove(self::PARAM, self::PARAM.'_again');
     }
 
+    /**
+     * @group https://github.com/AgencyPMG/cred-commands/issues/3
+     */
+    public function testMoreThanTenParametersCanBeRecievedAndRemoved()
+    {
+        $names = [];
+        $value = bin2hex(random_bytes(4));
+        foreach(range(1, 15) as $i) {
+            $names[] = $name = self::PARAM.'_multi_'.$i;
+            $this->client->put($name, $value);
+        }
+
+        $creds = $this->client->getMultiple(...$names);
+
+        $this->assertCount(15, $creds);
+        $this->assertEquals(array_fill_keys($names, $value), $creds);
+
+        $this->client->remove(...$names);
+    }
+
     public function testGettingMultipleParametersWithInvalidParamsCausesError()
     {
         $this->expectException(InvalidParameters::class);


### PR DESCRIPTION
The client itself will still return all parameters requested, but may make more than one request to do so.

Closes #3 